### PR TITLE
Update requirements.txt for imageio

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,4 +14,4 @@ pydantic
 compel
 easydict
 rotary_embedding_torch
-imageio
+imageio[ffmpeg]


### PR DESCRIPTION
When I cloned this project and installed the related dependencies, I got an error the first time I ran train.py.
```
Traceback (most recent call last):
  File "/root/animate-anything/train.py", line 1167, in <module>
    main_eval(**args_dict)
  File "/root/animate-anything/train.py", line 1154, in main_eval
    batch_eval(unet, text_encoder, vae, vae_processor, lora_manager, pretrained_model_path,
  File "/root/animate-anything/train.py", line 1114, in batch_eval
    precision = eval(pipeline, vae_processor,
  File "/root/animate-anything/train.py", line 1068, in eval
    imageio.mimwrite(out_file, video_frames, fps=validation_data.get('fps', 8))
  File "/root/animate-anything/venv/lib/python3.10/site-packages/imageio/v2.py", line 494, in mimwrite
    with imopen(uri, "wI", **imopen_args) as file:
  File "/root/animate-anything/venv/lib/python3.10/site-packages/imageio/core/imopen.py", line 281, in imopen
    raise err_type(err_msg)
ValueError: Could not find a backend to open `output/demo/f_3_2_s/0.mp4`` with iomode `wI`.
Based on the extension, the following plugins might add capable backends:
  FFMPEG:  pip install imageio[ffmpeg]
  pyav:  pip install imageio[pyav]
```
I think this is caused by not installing the relevant plugins for imageio, so we can update requirements.txt to avoid this error.