### PR TITLE
Fix text_encoder not on the GPU

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,4 @@ easydict
 rotary_embedding_torch
 imageio[ffmpeg]
 gradio
+httpx[socks]

--- a/train_svd.py
+++ b/train_svd.py
@@ -807,7 +807,8 @@ def main(
     weight_dtype = is_mixed_precision(accelerator)
 
     # Move text encoders, and VAE to GPU
-    cast_to_gpu_and_type([vae], accelerator.device, weight_dtype)
+    models_to_cast = [text_encoder, vae]
+    cast_to_gpu_and_type(models_to_cast, accelerator.device, weight_dtype)
     
     # We need to recalculate our total training steps as the size of the training dataloader may have changed.
     num_update_steps_per_epoch = math.ceil(len(train_dataloader) / gradient_accumulation_steps)


### PR DESCRIPTION
I got some errors when I ran train_svd.py:
```
Traceback (most recent call last):
  File "/root/sspaas-fs/animate-anything/train_svd.py", line 1089, in <module>
    main(**args_dict)
  File "/root/sspaas-fs/animate-anything/train_svd.py", line 886, in main
    loss = finetune_unet(pipeline, batch, use_offset_noise,
  File "/root/sspaas-fs/animate-anything/train_svd.py", line 541, in finetune_unet
    image_embeddings = pipeline._encode_image(images, device, 1, False)
  File "/root/sspaas-fs/animate-anything/venv/lib/python3.10/site-packages/diffusers/pipelines/stable_video_diffusion/pipeline_stable_video_diffusion.py", line 139, in _encode_image
    image_embeddings = self.image_encoder(image).image_embeds
  File "/root/sspaas-fs/animate-anything/venv/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1501, in _call_impl
    return forward_call(*args, **kwargs)
  File "/root/sspaas-fs/animate-anything/venv/lib/python3.10/site-packages/transformers/models/clip/modeling_clip.py", line 1287, in forward
    vision_outputs = self.vision_model(
  File "/root/sspaas-fs/animate-anything/venv/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1501, in _call_impl
    return forward_call(*args, **kwargs)
  File "/root/sspaas-fs/animate-anything/venv/lib/python3.10/site-packages/transformers/models/clip/modeling_clip.py", line 841, in forward
    hidden_states = self.embeddings(pixel_values)
  File "/root/sspaas-fs/animate-anything/venv/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1501, in _call_impl
    return forward_call(*args, **kwargs)
  File "/root/sspaas-fs/animate-anything/venv/lib/python3.10/site-packages/transformers/models/clip/modeling_clip.py", line 182, in forward
    patch_embeds = self.patch_embedding(pixel_values.to(dtype=target_dtype))  # shape = [*, width, grid, grid]
  File "/root/sspaas-fs/animate-anything/venv/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1501, in _call_impl
    return forward_call(*args, **kwargs)
  File "/root/sspaas-fs/animate-anything/venv/lib/python3.10/site-packages/torch/nn/modules/conv.py", line 463, in forward
    return self._conv_forward(input, self.weight, self.bias)
  File "/root/sspaas-fs/animate-anything/venv/lib/python3.10/site-packages/torch/nn/modules/conv.py", line 459, in _conv_forward
    return F.conv2d(input, weight, bias, self.stride,
RuntimeError: Input type (torch.cuda.HalfTensor) and weight type (torch.FloatTensor) should be the same
```
I believe this is because the train data was loaded onto the GPU, but the text_encoder within the pre-trained model was not on the GPU, which resulted in a failure to perform the convolutional computations.
When running app_svd.py, it is necessary to import the httpx[socks] package, otherwise an error will occur：
```
ImportError: Using SOCKS proxy, but the 'socksio' package is not installed. Make sure to install httpx using `pip install httpx[socks]`.
```

