### PR TITLE
fix seed not random when seed_textbox input with -1

### DIFF
--- a/app.py
+++ b/app.py
@@ -55,7 +55,7 @@ class AnimateController:
         progress=gr.Progress(),
     ):
 
-        if seed_textbox != -1 and seed_textbox != "":
+        if seed_textbox != "-1" and seed_textbox != "":
             torch.manual_seed(int(seed_textbox))
         else:
             torch.seed()

--- a/app_svd.py
+++ b/app_svd.py
@@ -49,7 +49,7 @@ class AnimateController:
         progress=gr.Progress(),
     ):
 
-        if seed_textbox != -1 and seed_textbox != "":
+        if seed_textbox != "-1" and seed_textbox != "":
             torch.manual_seed(int(seed_textbox))
         else:
             torch.seed()


### PR DESCRIPTION
When using the UI, I noticed that the same image always generates identical results, even though the seed input field was set to -1. Upon verification, it was identified that this issue was caused by not using the string type "-1" in the condition check.
