### PR TITLE
Optimize: Ensure video saving FPS is consistent with input parameter

### DIFF
--- a/app_svd.py
+++ b/app_svd.py
@@ -118,7 +118,7 @@ class AnimateController:
 
         save_sample_path = os.path.join(
             self.output_dir, f"{self.sample_idx}.mp4")
-        imageio.mimwrite(save_sample_path, video_frames, fps=7)
+        imageio.mimwrite(save_sample_path, video_frames, fps=validation_data.fps)
         self.sample_idx += 1
         return save_sample_path
 

--- a/train_svd.py
+++ b/train_svd.py
@@ -1039,8 +1039,8 @@ def eval(pipeline, vae_processor, validation_data, out_file, index, forward_t=25
             ).frames[0]
     
     if preview:
-        imageio.mimwrite(out_file, video_frames, duration=175, loop=0)
-        imageio.mimwrite(out_file.replace('.gif', '.mp4'), video_frames, fps=7)
+        imageio.mimwrite(out_file, video_frames, fps=validation_data.fps, loop=0)
+        imageio.mimwrite(out_file.replace('.gif', '.mp4'), video_frames, fps=validation_data.fps)
     return 0
 
 def main_eval(


### PR DESCRIPTION
I discovered that the fps used during video saving were inconsistent with the input parameters, so I optimized the code to align them.